### PR TITLE
Harden checkout flows and document setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Database
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/auto"
+
+# Admin session
+ADMIN_SESSION_SECRET="change-me"
+
+# Application URLs
+APP_BASE_URL="http://localhost:3000"
+
+# Stripe keys
+STRIPE_SECRET_KEY="sk_test_..."
+STRIPE_RESTAURANT_PRICE_ID="price_..."
+STRIPE_WEBHOOK_SECRET_KEY="whsec_..."
+NEXT_PUBLIC_STRIPE_PUBLIC_KEY="pk_test_..."

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,36 +1,83 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Auto Checkout Platform
 
-## Getting Started
+Aplicação full-stack construída com Next.js para oferecer onboarding de restaurantes, totem de autoatendimento para clientes e painel administrativo seguro.
 
-First, run the development server:
+## Visão geral
+
+O produto é composto por três pilares:
+
+- **Landing page de marketing** com formulário de trial de 7 dias integrado à Stripe.
+- **Fluxo público do totem** por slug do restaurante, com menu, sacola e checkout com pagamento online.
+- **Painel administrativo** protegido por sessão para gestão de cardápio, identidade visual e mídia.
+
+## Stack
+
+- [Next.js 15](https://nextjs.org/) com App Router
+- [Prisma ORM](https://www.prisma.io/) + PostgreSQL
+- [Stripe](https://stripe.com/) para billing e checkout
+- Tailwind CSS, Radix UI e shadcn/ui para a interface
+
+## Requisitos
+
+- Node.js 20+
+- Banco PostgreSQL disponível
+- Conta Stripe (modo teste) para gerar as chaves de API
+
+## Configuração
+
+1. Crie o arquivo de variáveis de ambiente a partir do template:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Preencha os valores solicitados:
+
+   | Variável | Descrição |
+   | --- | --- |
+   | `DATABASE_URL` | URL de conexão com o PostgreSQL.
+   | `ADMIN_SESSION_SECRET` | Chave aleatória para assinar a sessão do painel (`openssl rand -base64 32`).
+   | `APP_BASE_URL` | URL base do app (ex.: `http://localhost:3000`). Usada como fallback quando o header `origin` não está disponível.
+   | `STRIPE_SECRET_KEY` | Chave secreta da Stripe (modo teste).
+   | `STRIPE_RESTAURANT_PRICE_ID` | ID do preço/plan da assinatura criado na Stripe.
+   | `STRIPE_WEBHOOK_SECRET_KEY` | Secret do webhook configurado na Stripe.
+   | `NEXT_PUBLIC_STRIPE_PUBLIC_KEY` | Chave pública (publishable) da Stripe usada no cliente.
+
+3. Instale dependências e gere o client do Prisma:
+
+   ```bash
+   npm install
+   ```
+
+4. Aplique as migrações e popule dados base (opcional, mas recomendado para ter um restaurante demo):
+
+   ```bash
+   npx prisma migrate deploy
+   npx prisma db seed
+   ```
+
+## Executando em desenvolvimento
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+O aplicativo estará disponível em `http://localhost:3000`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Scripts úteis
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- `npm run lint` — roda as checagens de ESLint/TypeScript.
+- `npx prisma studio` — abre o Prisma Studio para inspecionar o banco.
 
-## Learn More
+## Webhooks da Stripe
 
-To learn more about Next.js, take a look at the following resources:
+Configure um endpoint na Stripe apontando para `/api/webhooks/stripe` e utilize o secret correspondente em `STRIPE_WEBHOOK_SECRET_KEY` para validar as assinaturas.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Deploy na Vercel
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+1. Crie um projeto na Vercel apontando para este repositório.
+2. Configure todas as variáveis de ambiente citadas acima na Vercel.
+3. Garanta que o banco de produção esteja acessível e rode `npx prisma migrate deploy` via Vercel Deploy Hooks ou manualmente.
+4. Após o deploy, atualize o campo `APP_BASE_URL` com a URL final (ex.: `https://seuapp.vercel.app`).
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Com isso, o projeto estará pronto para ser usado como MVP após o deploy.

--- a/src/app/[slug]/menu/actions/create-order.ts
+++ b/src/app/[slug]/menu/actions/create-order.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 
 import { db } from "@/lib/prisma";
 
-import { removeCpfPunctuation } from "../helpers/cpf";
+import { isValidCpf, removeCpfPunctuation } from "../helpers/cpf";
 
 interface CreateOrderInput {
   customerName: string;
@@ -19,6 +19,30 @@ interface CreateOrderInput {
 }
 
 export const createOrder = async (input: CreateOrderInput) => {
+  const trimmedName = input.customerName.trim();
+  if (!trimmedName) {
+    throw new Error("Customer name is required");
+  }
+
+  if (
+    !input.consumptionMethod ||
+    !Object.values(ConsumptionMethod).includes(input.consumptionMethod)
+  ) {
+    throw new Error("Invalid consumption method");
+  }
+
+  if (!isValidCpf(input.customerCpf)) {
+    throw new Error("Invalid CPF");
+  }
+
+  if (!input.products.length) {
+    throw new Error("Cart is empty");
+  }
+
+  if (input.products.some((product) => product.quantity <= 0)) {
+    throw new Error("All products must have quantity greater than zero");
+  }
+
   const restaurant = await db.restaurant.findUnique({
     where: {
       slug: input.slug,
@@ -34,25 +58,41 @@ export const createOrder = async (input: CreateOrderInput) => {
       },
     },
   });
+  const priceByProductId = new Map(
+    productsWithPrices.map((product) => [product.id, product.price]),
+  );
+
+  const missingProduct = input.products.find(
+    (product) => !priceByProductId.has(product.id),
+  );
+
+  if (missingProduct) {
+    throw new Error(`Product ${missingProduct.id} is no longer available`);
+  }
+
   const productsWithPricesAndQuantities = input.products.map((product) => ({
     productId: product.id,
     quantity: product.quantity,
-    price: productsWithPrices.find((p) => p.id === product.id)!.price,
+    price: priceByProductId.get(product.id)!,
   }));
+
+  const sanitizedCpf = removeCpfPunctuation(input.customerCpf);
+  const orderTotal = productsWithPricesAndQuantities.reduce(
+    (acc, product) => acc + product.price * product.quantity,
+    0,
+  );
+
   const order = await db.order.create({
     data: {
       status: "PENDING",
-      customerName: input.customerName,
-      customerCpf: removeCpfPunctuation(input.customerCpf),
+      customerName: trimmedName,
+      customerCpf: sanitizedCpf,
       orderProducts: {
         createMany: {
           data: productsWithPricesAndQuantities,
         },
       },
-      total: productsWithPricesAndQuantities.reduce(
-        (acc, product) => acc + product.price * product.quantity,
-        0,
-      ),
+      total: orderTotal,
       consumptionMethod: input.consumptionMethod,
       restaurantId: restaurant.id,
     },

--- a/src/app/[slug]/menu/actions/create-stripe-checkout.ts
+++ b/src/app/[slug]/menu/actions/create-stripe-checkout.ts
@@ -7,7 +7,7 @@ import Stripe from "stripe";
 import { db } from "@/lib/prisma";
 
 import { CartProduct } from "../contexts/cart";
-import { removeCpfPunctuation } from "../helpers/cpf";
+import { isValidCpf, removeCpfPunctuation } from "../helpers/cpf";
 
 interface CreateStripeCheckoutInput {
   products: CartProduct[];
@@ -27,7 +27,18 @@ export const createStripeCheckout = async ({
   if (!process.env.STRIPE_SECRET_KEY) {
     throw new Error("Missing Stripe secret key");
   }
-  const origin = (await headers()).get("origin") as string;
+  if (!products.length) {
+    throw new Error("Cannot create a checkout session without products");
+  }
+
+  if (!isValidCpf(cpf)) {
+    throw new Error("Invalid CPF");
+  }
+
+  const headerList = headers();
+  const originHeader = headerList.get("origin") ?? process.env.APP_BASE_URL;
+  const baseUrl = originHeader?.replace(/\/$/, "") ?? "http://localhost:3000";
+
   const productsWithPrices = await db.product.findMany({
     where: {
       id: {
@@ -35,17 +46,30 @@ export const createStripeCheckout = async ({
       },
     },
   });
+  const priceByProductId = new Map(
+    productsWithPrices.map((product) => [product.id, product.price]),
+  );
+
+  const missingProduct = products.find(
+    (product) => !priceByProductId.has(product.id),
+  );
+
+  if (missingProduct) {
+    throw new Error(`Product ${missingProduct.id} is no longer available`);
+  }
+
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
     apiVersion: "2025-02-24.acacia",
   });
   const searchParams = new URLSearchParams();
   searchParams.set("consumptionMethod", consumptionMethod);
-  searchParams.set("cpf", removeCpfPunctuation(cpf));
+  const sanitizedCpf = removeCpfPunctuation(cpf);
+  searchParams.set("cpf", sanitizedCpf);
   const session = await stripe.checkout.sessions.create({
     payment_method_types: ["card"],
     mode: "payment",
-    success_url: `${origin}/${slug}/orders?${searchParams.toString()}`,
-    cancel_url: `${origin}/${slug}/orders?${searchParams.toString()}`,
+    success_url: `${baseUrl}/${slug}/orders?${searchParams.toString()}`,
+    cancel_url: `${baseUrl}/${slug}/orders?${searchParams.toString()}`,
     metadata: {
       orderId,
     },
@@ -54,10 +78,9 @@ export const createStripeCheckout = async ({
         currency: "brl",
         product_data: {
           name: product.name,
-          images: [product.imageUrl],
+          images: product.imageUrl ? [product.imageUrl] : undefined,
         },
-        unit_amount:
-          productsWithPrices.find((p) => p.id === product.id)!.price * 100,
+        unit_amount: Math.round(priceByProductId.get(product.id)! * 100),
       },
       quantity: product.quantity,
     })),

--- a/src/app/[slug]/orders/page.tsx
+++ b/src/app/[slug]/orders/page.tsx
@@ -10,12 +10,15 @@ import OrderList from "./components/order-list";
 
 interface OrdersPageProps {
   params: { slug: string };
-  searchParams: Promise<{ cpf?: string }>;
+  searchParams?: { cpf?: string };
 }
 
-const OrdersPage = async ({ params, searchParams }: OrdersPageProps) => {
+const OrdersPage = async ({
+  params,
+  searchParams = {},
+}: OrdersPageProps) => {
   const { slug } = params;
-  const { cpf } = await searchParams;
+  const { cpf } = searchParams;
   const restaurant = await db.restaurant.findUnique({ where: { slug } });
   if (!restaurant) {
     return notFound();


### PR DESCRIPTION
## Summary
- add an `.env.example` template and expand the README with setup, Stripe and deploy guidance
- tighten server-side validation for order creation and Stripe checkout, including CPF checks and origin fallbacks
- fix the orders page to use synchronous search params handling compatible with the App Router

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e68cbc85fc832fa78dd1a57535c6f7